### PR TITLE
Adição do atributo peso_carga à classe StatusEntrega

### DIFF
--- a/status_entrega.rb
+++ b/status_entrega.rb
@@ -1,11 +1,12 @@
 # status_entrega.rb
 class StatusEntrega
-  attr_accessor :clima, :estrada, :zona, :distancia
+  attr_accessor :clima, :estrada, :zona, :distancia, :pose_carga
 
-  def initialize(clima="sol", estrada="asfalto", zona="urbana", distancia=0)
+  def initialize(clima="sol", estrada="asfalto", zona="urbana", distancia=0, peso_carga = 0)
     @clima = clima
     @estrada = estrada
     @zona = zona
     @distancia = distancia
+    @peso_carga = peso_carga
   end
 end


### PR DESCRIPTION
Este commit introduz o atributo peso_carga à classe StatusEntrega, representando o peso da carga transportada (em quilogramas).

A presença deste novo atributo permite que o sistema leve em consideração a carga no momento de aplicar regras, restrições e cálculos logísticos, como:

Limites operacionais por tipo de transporte (ex: drones com carga leve).

Impacto no tempo ou custo da entrega com base no peso.

O construtor principal foi ajustado para receber peso_carga como quinto parâmetro, mantendo a coerência e a flexibilidade da modelagem.